### PR TITLE
Improve location service initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,17 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-3. Run the application:
+3. Create a `.env` file with your configuration. At a minimum set
+`GOOGLE_MAPS_API_KEY=<your key>` or set `MOCK_LOCATION_SERVICE=true` to enable
+mock responses. If the key is missing and mock mode is not enabled, the
+location service will raise a `RuntimeError` on startup.
+
+4. Run the application:
 ```bash
 uvicorn main:app --reload
 ```
 
-4. Access the API documentation:
+5. Access the API documentation:
 - OpenAPI UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 

--- a/shared/location_service.py
+++ b/shared/location_service.py
@@ -29,21 +29,24 @@ class LocationService:
 
     def _initialize_clients(self) -> None:
         """Initialize API clients with proper error handling."""
-        if not self.mock_mode:
-            try:
-                api_key = os.getenv("GOOGLE_MAPS_API_KEY")
-                if not api_key:
-                    logger.warning("GOOGLE_MAPS_API_KEY not found in environment, falling back to mock mode")
-                    self.mock_mode = True
-                    return
-                    
-                self.gmaps = googlemaps.Client(key=api_key)
-                self.tf = TimezoneFinder()
-                logger.info("Successfully initialized Google Maps client")
-            except Exception as e:
-                logger.error(f"Failed to initialize Google Maps client: {str(e)}")
-                self.mock_mode = True
-                logger.warning("Falling back to mock mode due to initialization error")
+        if self.mock_mode:
+            logger.info("Mock mode enabled for LocationService")
+            return
+
+        api_key = os.getenv("GOOGLE_MAPS_API_KEY")
+        if not api_key:
+            logger.error("GOOGLE_MAPS_API_KEY not found in environment")
+            raise RuntimeError(
+                "GOOGLE_MAPS_API_KEY is required when MOCK_LOCATION_SERVICE is not true"
+            )
+
+        try:
+            self.gmaps = googlemaps.Client(key=api_key)
+            self.tf = TimezoneFinder()
+            logger.info("Successfully initialized Google Maps client")
+        except Exception as e:
+            logger.error(f"Failed to initialize Google Maps client: {str(e)}")
+            raise RuntimeError("Failed to initialize Google Maps client") from e
 
     def _get_mock_location(self, address: str) -> Dict[str, Any]:
         """Generate mock location data for testing."""


### PR DESCRIPTION
## Summary
- require `GOOGLE_MAPS_API_KEY` when mock mode is off
- document new behavior in README

## Testing
- `pytest -q`
- `python -m py_compile shared/location_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68463c3cb314832cae5e8de68cdb5953