### PR TITLE
Add API URL config support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration for client apps
+# Base URL of the running FastAPI server
+EXPO_PUBLIC_API_URL=http://localhost:8000
+
+# Public Clerk key used in App.tsx
+EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=your_clerk_key

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ everything-app/
 - TTS uses pyttsx3 for welcome messages
 - In-memory storage is used for POC
 
+## Client Configuration
+
+The client applications read the FastAPI endpoint from environment variables.
+Create a `.env` file in the project root (see `.env.example`) and define
+`EXPO_PUBLIC_API_URL` to point to your API server. This works for both the web
+app (Expo web) and the native mobile build.
+
 ## Future Enhancements
 
 - OpenAI integration for natural language processing

--- a/os-manager-mobile/README.md
+++ b/os-manager-mobile/README.md
@@ -16,6 +16,12 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npx expo start
    ```
 
+### Environment configuration
+
+Create a `.env` file in the project root and set `EXPO_PUBLIC_API_URL` to the
+address of your FastAPI server. See the repository's `.env.example` for a
+template.
+
 In the output, you'll find options to open the app in a
 
 - [development build](https://docs.expo.dev/develop/development-builds/introduction/)

--- a/src/components/VoiceControl.tsx
+++ b/src/components/VoiceControl.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { MicrophoneIcon, StopIcon } from '@heroicons/react/24/solid';
+import { API_URL, WS_URL } from '../config';
 
 interface VoiceControlProps {
   onCommand: (command: string) => void;
@@ -15,7 +16,7 @@ export default function VoiceControl({ onCommand }: VoiceControlProps) {
   useEffect(() => {
     // Initialize WebSocket connection
     const connectWebSocket = () => {
-      const ws = new WebSocket('ws://localhost:8000/voice/ws');
+      const ws = new WebSocket(`${WS_URL}/voice/ws`);
 
       ws.onopen = () => {
         setStatus('Connected to voice service');
@@ -63,7 +64,7 @@ export default function VoiceControl({ onCommand }: VoiceControlProps) {
 
   const updateWakeWord = async () => {
     try {
-      const response = await fetch('http://localhost:8000/voice/wake-word', {
+      const response = await fetch(`${API_URL}/voice/wake-word`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,2 @@
+export const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
+export const WS_URL = API_URL.replace(/^http/, 'ws');

--- a/src/screens/FileSystemScreen.tsx
+++ b/src/screens/FileSystemScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, FlatList, Switch } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
+import { API_URL } from '../config';
 
 interface FileItem {
   name: string;
@@ -17,7 +18,7 @@ export default function FileSystemScreen() {
   const { data, isLoading, refetch } = useQuery<FileItem[]>({
     queryKey: ['files', currentPath],
     queryFn: async () => {
-      const response = await fetch(`http://localhost:8000/files?path=${encodeURIComponent(currentPath)}&show_hidden=${showHidden}`);
+      const response = await fetch(`${API_URL}/files?path=${encodeURIComponent(currentPath)}&show_hidden=${showHidden}`);
       return response.json();
     }
   });

--- a/src/screens/ProcessesScreen.tsx
+++ b/src/screens/ProcessesScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, FlatList } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
+import { API_URL } from '../config';
 
 interface Process {
   pid: number;
@@ -17,7 +18,7 @@ export default function ProcessesScreen() {
   const { data, isLoading, refetch } = useQuery<Process[]>({
     queryKey: ['processes'],
     queryFn: async () => {
-      const response = await fetch('http://localhost:8000/processes');
+      const response = await fetch(`${API_URL}/processes`);
       return response.json();
     },
     refetchInterval: 5000 // Refresh every 5 seconds

--- a/src/screens/SystemInfoScreen.tsx
+++ b/src/screens/SystemInfoScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, ScrollView, RefreshControl } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
+import { API_URL } from '../config';
 
 interface SystemInfo {
   cpuUsage: number;
@@ -16,7 +17,7 @@ export default function SystemInfoScreen() {
   const { data, isLoading, refetch } = useQuery<SystemInfo>({
     queryKey: ['systemInfo'],
     queryFn: async () => {
-      const response = await fetch('http://localhost:8000/system/info');
+      const response = await fetch(`${API_URL}/system/info`);
       return response.json();
     }
   });


### PR DESCRIPTION
## Summary
- add a config file that reads `EXPO_PUBLIC_API_URL`
- use that config in VoiceControl and all screens
- provide `.env.example` for easier setup
- document environment usage for Expo web/mobile clients

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cd os-manager-mobile && npx tsc --noEmit` *(fails: Cannot find module ...)*

------
https://chatgpt.com/codex/tasks/task_e_68463fd1b15c832c90fe717b6bf075da