### PR TITLE
Switch routers to SQLite models

### DIFF
--- a/agents/inventory_manager/database.py
+++ b/agents/inventory_manager/database.py
@@ -1,6 +1,9 @@
-from sqlalchemy import create_engine, Column, Integer, String, DateTime, Enum as SQLEnum, Float
+from sqlalchemy import (
+    create_engine, Column, Integer, String, DateTime, Enum as SQLEnum,
+    Float, ForeignKey
+)
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, relationship
 import os
 from datetime import datetime
 from typing import Optional
@@ -26,6 +29,35 @@ class InventoryItemDB(Base):
     last_updated = Column(DateTime, default=datetime.now)
     low_stock_threshold = Column(Float, default=2.0)
     notes = Column(String(500), nullable=True)
+
+class ReceiptDB(Base):
+    """Database model for purchase receipts"""
+    __tablename__ = "receipts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    store_name = Column(String(100))
+    purchase_date = Column(DateTime)
+    total_amount = Column(Float)
+    payment_method = Column(String(50))
+    notes = Column(String(500), nullable=True)
+    created_at = Column(DateTime, default=datetime.now)
+
+    items = relationship("ReceiptItemDB", back_populates="receipt", cascade="all, delete-orphan")
+
+
+class ReceiptItemDB(Base):
+    """Database model for receipt line items"""
+    __tablename__ = "receipt_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    receipt_id = Column(Integer, ForeignKey("receipts.id"))
+    item_name = Column(String(100))
+    quantity = Column(Float)
+    unit_price = Column(Float)
+    total_price = Column(Float)
+    category = Column(String(50), nullable=True)
+
+    receipt = relationship("ReceiptDB", back_populates="items")
 
 # Create tables
 Base.metadata.create_all(bind=engine)

--- a/agents/smart_home/database.py
+++ b/agents/smart_home/database.py
@@ -58,6 +58,19 @@ class EventLogDB(Base):
     event_type = Column(String(50))  # e.g., "arrival", "light_control", "security_change"
     details = Column(JSON)  # Store event details as JSON
 
+
+class DeviceDB(Base):
+    """Database model for smart home devices"""
+    __tablename__ = "devices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100))
+    type = Column(String(50))
+    location = Column(String(100))
+    status = Column(SQLEnum(DeviceStatus), default=DeviceStatus.OFF)
+    settings = Column(JSON, default={})
+    last_updated = Column(DateTime, default=datetime.now)
+
 # Create tables
 Base.metadata.create_all(bind=engine)
 

--- a/inventory_manager/routers/receipts.py
+++ b/inventory_manager/routers/receipts.py
@@ -1,7 +1,9 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime
+from sqlalchemy.orm import Session
+from agents.inventory_manager.database import get_db, ReceiptDB, ReceiptItemDB
 
 router = APIRouter(
     prefix="/receipts",
@@ -34,77 +36,145 @@ class Receipt(ReceiptBase):
     class Config:
         from_attributes = True
 
-# Temporary in-memory storage
-receipts_db = []
-receipt_id_counter = 1
+# Database backed storage
 
 @router.post("/", response_model=Receipt)
-async def create_receipt(receipt: ReceiptCreate):
-    global receipt_id_counter
-    new_receipt = Receipt(
-        **receipt.model_dump(),
-        id=receipt_id_counter,
-        created_at=datetime.now()
+async def create_receipt(receipt: ReceiptCreate, db: Session = Depends(get_db)):
+    db_receipt = ReceiptDB(
+        store_name=receipt.store_name,
+        purchase_date=receipt.purchase_date,
+        total_amount=receipt.total_amount,
+        payment_method=receipt.payment_method,
+        notes=receipt.notes,
+        created_at=datetime.now(),
     )
-    receipts_db.append(new_receipt)
-    receipt_id_counter += 1
-    return new_receipt
+    db.add(db_receipt)
+    db.commit()
+    db.refresh(db_receipt)
+
+    for item in receipt.items:
+        db_item = ReceiptItemDB(
+            receipt_id=db_receipt.id,
+            item_name=item.item_name,
+            quantity=item.quantity,
+            unit_price=item.unit_price,
+            total_price=item.total_price,
+            category=item.category,
+        )
+        db.add(db_item)
+    db.commit()
+
+    return Receipt(
+        id=db_receipt.id,
+        created_at=db_receipt.created_at,
+        **receipt.model_dump(),
+    )
 
 @router.get("/", response_model=List[Receipt])
 async def get_receipts(
     store_name: Optional[str] = None,
     start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None,
+    db: Session = Depends(get_db),
 ):
-    filtered_receipts = receipts_db
-    
+    query = db.query(ReceiptDB)
+
     if store_name:
-        filtered_receipts = [r for r in filtered_receipts if r.store_name == store_name]
+        query = query.filter(ReceiptDB.store_name == store_name)
     if start_date:
-        filtered_receipts = [r for r in filtered_receipts if r.purchase_date >= start_date]
+        query = query.filter(ReceiptDB.purchase_date >= start_date)
     if end_date:
-        filtered_receipts = [r for r in filtered_receipts if r.purchase_date <= end_date]
-    
-    return filtered_receipts
+        query = query.filter(ReceiptDB.purchase_date <= end_date)
+
+    receipts = query.all()
+    results = []
+    for r in receipts:
+        items = db.query(ReceiptItemDB).filter(ReceiptItemDB.receipt_id == r.id).all()
+        results.append(
+            Receipt(
+                id=r.id,
+                store_name=r.store_name,
+                purchase_date=r.purchase_date,
+                total_amount=r.total_amount,
+                payment_method=r.payment_method,
+                notes=r.notes,
+                created_at=r.created_at,
+                items=[
+                    ReceiptItemBase(
+                        item_name=i.item_name,
+                        quantity=i.quantity,
+                        unit_price=i.unit_price,
+                        total_price=i.total_price,
+                        category=i.category,
+                    )
+                    for i in items
+                ],
+            )
+        )
+    return results
 
 @router.get("/{receipt_id}", response_model=Receipt)
-async def get_receipt(receipt_id: int):
-    for receipt in receipts_db:
-        if receipt.id == receipt_id:
-            return receipt
-    raise HTTPException(status_code=404, detail="Receipt not found")
+async def get_receipt(receipt_id: int, db: Session = Depends(get_db)):
+    r = db.query(ReceiptDB).filter(ReceiptDB.id == receipt_id).first()
+    if not r:
+        raise HTTPException(status_code=404, detail="Receipt not found")
+    items = db.query(ReceiptItemDB).filter(ReceiptItemDB.receipt_id == r.id).all()
+    return Receipt(
+        id=r.id,
+        store_name=r.store_name,
+        purchase_date=r.purchase_date,
+        total_amount=r.total_amount,
+        payment_method=r.payment_method,
+        notes=r.notes,
+        created_at=r.created_at,
+        items=[
+            ReceiptItemBase(
+                item_name=i.item_name,
+                quantity=i.quantity,
+                unit_price=i.unit_price,
+                total_price=i.total_price,
+                category=i.category,
+            )
+            for i in items
+        ],
+    )
 
 @router.delete("/{receipt_id}")
-async def delete_receipt(receipt_id: int):
-    for i, receipt in enumerate(receipts_db):
-        if receipt.id == receipt_id:
-            del receipts_db[i]
-            return {"message": "Receipt deleted"}
-    raise HTTPException(status_code=404, detail="Receipt not found")
+async def delete_receipt(receipt_id: int, db: Session = Depends(get_db)):
+    r = db.query(ReceiptDB).filter(ReceiptDB.id == receipt_id).first()
+    if not r:
+        raise HTTPException(status_code=404, detail="Receipt not found")
+    db.query(ReceiptItemDB).filter(ReceiptItemDB.receipt_id == receipt_id).delete()
+    db.delete(r)
+    db.commit()
+    return {"message": "Receipt deleted"}
 
 @router.get("/stores")
-async def get_stores():
-    return list(set(receipt.store_name for receipt in receipts_db))
+async def get_stores(db: Session = Depends(get_db)):
+    stores = db.query(ReceiptDB.store_name).distinct().all()
+    return [s[0] for s in stores]
 
 @router.get("/summary")
 async def get_expense_summary(
     start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None,
+    db: Session = Depends(get_db),
 ):
-    filtered_receipts = receipts_db
-    
+    query = db.query(ReceiptDB)
+
     if start_date:
-        filtered_receipts = [r for r in filtered_receipts if r.purchase_date >= start_date]
+        query = query.filter(ReceiptDB.purchase_date >= start_date)
     if end_date:
-        filtered_receipts = [r for r in filtered_receipts if r.purchase_date <= end_date]
-    
-    total_spent = sum(r.total_amount for r in filtered_receipts)
+        query = query.filter(ReceiptDB.purchase_date <= end_date)
+
+    receipts = query.all()
+    total_spent = sum(r.total_amount for r in receipts)
     store_totals = {}
-    for receipt in filtered_receipts:
-        store_totals[receipt.store_name] = store_totals.get(receipt.store_name, 0) + receipt.total_amount
-    
+    for r in receipts:
+        store_totals[r.store_name] = store_totals.get(r.store_name, 0) + r.total_amount
+
     return {
         "total_spent": total_spent,
-        "receipt_count": len(filtered_receipts),
+        "receipt_count": len(receipts),
         "store_totals": store_totals
-    } 
+    }

--- a/life_organizer/routers/reminders.py
+++ b/life_organizer/routers/reminders.py
@@ -1,7 +1,9 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from typing import List, Optional
 from datetime import datetime
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from agents.life_organizer.database import get_db, ReminderDB
 
 router = APIRouter(
     prefix="/reminders",
@@ -26,59 +28,88 @@ class Reminder(ReminderBase):
     class Config:
         from_attributes = True
 
-# Temporary in-memory storage
-reminders_db = []
-reminder_id_counter = 1
+# Database backed storage
 
 @router.post("/", response_model=Reminder)
-async def create_reminder(reminder: ReminderCreate):
-    global reminder_id_counter
-    new_reminder = Reminder(
-        **reminder.model_dump(),
-        id=reminder_id_counter,
-        created_at=datetime.now()
+async def create_reminder(reminder: ReminderCreate, db: Session = Depends(get_db)):
+    db_reminder = ReminderDB(
+        title=reminder.title,
+        description=reminder.description,
+        due_date=reminder.due_date,
+        priority=reminder.priority,
+        completed=False,
+        created_at=datetime.now(),
     )
-    reminders_db.append(new_reminder)
-    reminder_id_counter += 1
-    return new_reminder
+    db.add(db_reminder)
+    db.commit()
+    db.refresh(db_reminder)
+    return Reminder(**reminder.model_dump(), id=db_reminder.id, created_at=db_reminder.created_at)
 
 @router.get("/", response_model=List[Reminder])
-async def get_reminders():
-    return reminders_db
+async def get_reminders(db: Session = Depends(get_db)):
+    reminders = db.query(ReminderDB).all()
+    return [
+        Reminder(
+            id=r.id,
+            title=r.title,
+            description=r.description,
+            due_date=r.due_date,
+            priority=r.priority,
+            created_at=r.created_at,
+            completed=r.completed,
+        )
+        for r in reminders
+    ]
 
 @router.get("/{reminder_id}", response_model=Reminder)
-async def get_reminder(reminder_id: int):
-    for reminder in reminders_db:
-        if reminder.id == reminder_id:
-            return reminder
-    raise HTTPException(status_code=404, detail="Reminder not found")
+async def get_reminder(reminder_id: int, db: Session = Depends(get_db)):
+    r = db.query(ReminderDB).filter(ReminderDB.id == reminder_id).first()
+    if not r:
+        raise HTTPException(status_code=404, detail="Reminder not found")
+    return Reminder(
+        id=r.id,
+        title=r.title,
+        description=r.description,
+        due_date=r.due_date,
+        priority=r.priority,
+        created_at=r.created_at,
+        completed=r.completed,
+    )
 
 @router.put("/{reminder_id}", response_model=Reminder)
-async def update_reminder(reminder_id: int, reminder: ReminderCreate):
-    for i, existing_reminder in enumerate(reminders_db):
-        if existing_reminder.id == reminder_id:
-            updated_reminder = Reminder(
-                **reminder.model_dump(),
-                id=reminder_id,
-                created_at=existing_reminder.created_at,
-                completed=existing_reminder.completed
-            )
-            reminders_db[i] = updated_reminder
-            return updated_reminder
-    raise HTTPException(status_code=404, detail="Reminder not found")
+async def update_reminder(reminder_id: int, reminder: ReminderCreate, db: Session = Depends(get_db)):
+    db_reminder = db.query(ReminderDB).filter(ReminderDB.id == reminder_id).first()
+    if not db_reminder:
+        raise HTTPException(status_code=404, detail="Reminder not found")
+
+    for field, value in reminder.model_dump().items():
+        setattr(db_reminder, field, value)
+    db.commit()
+    db.refresh(db_reminder)
+    return Reminder(
+        id=db_reminder.id,
+        title=db_reminder.title,
+        description=db_reminder.description,
+        due_date=db_reminder.due_date,
+        priority=db_reminder.priority,
+        created_at=db_reminder.created_at,
+        completed=db_reminder.completed,
+    )
 
 @router.delete("/{reminder_id}")
-async def delete_reminder(reminder_id: int):
-    for i, reminder in enumerate(reminders_db):
-        if reminder.id == reminder_id:
-            del reminders_db[i]
-            return {"message": "Reminder deleted"}
-    raise HTTPException(status_code=404, detail="Reminder not found")
+async def delete_reminder(reminder_id: int, db: Session = Depends(get_db)):
+    db_reminder = db.query(ReminderDB).filter(ReminderDB.id == reminder_id).first()
+    if not db_reminder:
+        raise HTTPException(status_code=404, detail="Reminder not found")
+    db.delete(db_reminder)
+    db.commit()
+    return {"message": "Reminder deleted"}
 
 @router.post("/{reminder_id}/complete")
-async def complete_reminder(reminder_id: int):
-    for reminder in reminders_db:
-        if reminder.id == reminder_id:
-            reminder.completed = True
-            return {"message": "Reminder marked as completed"}
-    raise HTTPException(status_code=404, detail="Reminder not found") 
+async def complete_reminder(reminder_id: int, db: Session = Depends(get_db)):
+    db_reminder = db.query(ReminderDB).filter(ReminderDB.id == reminder_id).first()
+    if not db_reminder:
+        raise HTTPException(status_code=404, detail="Reminder not found")
+    db_reminder.completed = True
+    db.commit()
+    return {"message": "Reminder marked as completed"}

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,0 +1,6 @@
+from agents.inventory_manager import database as inv_db
+from agents.life_organizer import database as org_db
+from agents.smart_home import database as sh_db
+
+# Importing the modules triggers table creation via metadata.create_all
+print("Databases initialized.")

--- a/smart_home/routers/events.py
+++ b/smart_home/routers/events.py
@@ -1,7 +1,9 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime
+from sqlalchemy.orm import Session
+from agents.smart_home.database import get_db, EventLogDB
 
 router = APIRouter(
     prefix="/events",
@@ -26,56 +28,99 @@ class Event(EventBase):
     class Config:
         from_attributes = True
 
-# Temporary in-memory storage
-events_db = []
-event_id_counter = 1
+# Database backed storage
 
 @router.post("/", response_model=Event)
-async def create_event(event: EventCreate):
-    global event_id_counter
-    new_event = Event(
-        **event.model_dump(),
-        id=event_id_counter,
-        timestamp=datetime.now()
+async def create_event(event: EventCreate, db: Session = Depends(get_db)):
+    db_event = EventLogDB(
+        event_type=event.event_type,
+        details={
+            "device_id": event.device_id,
+            "description": event.description,
+            "severity": event.severity,
+            "metadata": event.metadata,
+        },
+        timestamp=datetime.now(),
     )
-    events_db.append(new_event)
-    event_id_counter += 1
-    return new_event
+    db.add(db_event)
+    db.commit()
+    db.refresh(db_event)
+    return Event(
+        id=db_event.id,
+        device_id=event.device_id,
+        event_type=event.event_type,
+        description=event.description,
+        severity=event.severity,
+        metadata=event.metadata,
+        timestamp=db_event.timestamp,
+    )
 
 @router.get("/", response_model=List[Event])
 async def get_events(
     device_id: Optional[int] = None,
     event_type: Optional[str] = None,
     severity: Optional[str] = None,
-    limit: int = 100
+    limit: int = 100,
+    db: Session = Depends(get_db),
 ):
-    filtered_events = events_db
-    
-    if device_id:
-        filtered_events = [e for e in filtered_events if e.device_id == device_id]
+    query = db.query(EventLogDB)
+    if device_id is not None:
+        query = query.filter(EventLogDB.details["device_id"].as_integer() == device_id)
     if event_type:
-        filtered_events = [e for e in filtered_events if e.event_type == event_type]
+        query = query.filter(EventLogDB.event_type == event_type)
     if severity:
-        filtered_events = [e for e in filtered_events if e.severity == severity]
-    
-    return filtered_events[-limit:]
+        query = query.filter(EventLogDB.details["severity"] == severity)
+
+    results = query.order_by(EventLogDB.timestamp.desc()).limit(limit).all()
+    return [
+        Event(
+            id=e.id,
+            device_id=e.details.get("device_id"),
+            event_type=e.event_type,
+            description=e.details.get("description", ""),
+            severity=e.details.get("severity", "info"),
+            metadata=e.details.get("metadata", {}),
+            timestamp=e.timestamp,
+        )
+        for e in results
+    ]
 
 @router.get("/{event_id}", response_model=Event)
-async def get_event(event_id: int):
-    for event in events_db:
-        if event.id == event_id:
-            return event
-    raise HTTPException(status_code=404, detail="Event not found")
+async def get_event(event_id: int, db: Session = Depends(get_db)):
+    e = db.query(EventLogDB).filter(EventLogDB.id == event_id).first()
+    if not e:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return Event(
+        id=e.id,
+        device_id=e.details.get("device_id"),
+        event_type=e.event_type,
+        description=e.details.get("description", ""),
+        severity=e.details.get("severity", "info"),
+        metadata=e.details.get("metadata", {}),
+        timestamp=e.timestamp,
+    )
 
 @router.delete("/{event_id}")
-async def delete_event(event_id: int):
-    for i, event in enumerate(events_db):
-        if event.id == event_id:
-            del events_db[i]
-            return {"message": "Event deleted"}
-    raise HTTPException(status_code=404, detail="Event not found")
+async def delete_event(event_id: int, db: Session = Depends(get_db)):
+    e = db.query(EventLogDB).filter(EventLogDB.id == event_id).first()
+    if not e:
+        raise HTTPException(status_code=404, detail="Event not found")
+    db.delete(e)
+    db.commit()
+    return {"message": "Event deleted"}
 
 @router.get("/device/{device_id}", response_model=List[Event])
-async def get_device_events(device_id: int, limit: int = 50):
-    device_events = [e for e in events_db if e.device_id == device_id]
-    return device_events[-limit:] 
+async def get_device_events(device_id: int, limit: int = 50, db: Session = Depends(get_db)):
+    events = db.query(EventLogDB).filter(EventLogDB.details["device_id"].as_integer() == device_id).order_by(EventLogDB.timestamp.desc()).limit(limit).all()
+    return [
+        Event(
+            id=e.id,
+            device_id=device_id,
+            event_type=e.event_type,
+            description=e.details.get("description", ""),
+            severity=e.details.get("severity", "info"),
+            metadata=e.details.get("metadata", {}),
+            timestamp=e.timestamp,
+        )
+        for e in events
+    ]


### PR DESCRIPTION
## Summary
- swap in-memory lists for SQLAlchemy models
- persist inventory and receipts
- use DB-backed reminders and appointments
- record home events and devices in SQLite
- add database initialization script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68463fcdb70c832c95c27a4370c9a5be