### PR TITLE
Add APScheduler to manage periodic jobs

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import uvicorn
 from pathlib import Path
 import os
 from dotenv import load_dotenv
+from task_scheduler import router as scheduler_router, scheduler, add_scheduled_jobs
 from life_organizer.routers import reminders, appointments, location
 from smart_home.routers import home_control, events
 from inventory_manager.routers import inventory, receipts
@@ -46,6 +47,7 @@ app.include_router(receipts)
 app.include_router(system_info)
 app.include_router(file_system)
 app.include_router(process_mgmt)
+app.include_router(scheduler_router)
 
 @app.get("/")
 async def root():
@@ -59,6 +61,17 @@ async def root():
             "OS Manager (system info, file system, process management)"
         ]
     }
+
+
+@app.on_event("startup")
+async def start_scheduler():
+    add_scheduled_jobs()
+    scheduler.start()
+
+
+@app.on_event("shutdown")
+async def stop_scheduler():
+    scheduler.shutdown()
 
 if __name__ == "__main__":
     # Ensure required directories exist

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ passlib[bcrypt]>=1.7.4  # For password hashing
 googlemaps>=4.10.0  # For Google Maps integration
 timezonefinder>=6.2.0  # For getting timezone from coordinates
 pytz>=2024.1  # For timezone handling
-psutil>=5.9.0  # For system and process management 
+psutil>=5.9.0  # For system and process management
+apscheduler>=3.10.0

--- a/task_scheduler.py
+++ b/task_scheduler.py
@@ -1,0 +1,96 @@
+from fastapi import APIRouter, HTTPException
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+import logging
+from typing import List, Dict, Any
+from datetime import datetime
+import os
+
+from life_organizer.routers import reminders
+from inventory_manager.routers import inventory
+from shared.location_service import LocationService
+
+logger = logging.getLogger(__name__)
+
+# Scheduler instance
+scheduler = AsyncIOScheduler()
+
+router = APIRouter(prefix="/schedule", tags=["scheduler"])
+
+
+def send_due_reminders() -> None:
+    """Log reminders that are due."""
+    now = datetime.now()
+    due = [r for r in reminders.reminders_db if not r.completed and r.due_date <= now]
+    for r in due:
+        logger.info("Reminder due: %s", r.title)
+
+
+def check_low_stock() -> None:
+    """Log items that need restocking."""
+    items = inventory.get_low_stock_items()
+    if items:
+        names = ", ".join(item.name for item in items)
+        logger.info("Low stock items: %s", names)
+
+
+def update_commute_info() -> None:
+    """Retrieve commute info and log the duration."""
+    origin = os.getenv("COMMUTE_ORIGIN")
+    destination = os.getenv("COMMUTE_DESTINATION")
+    if not origin or not destination:
+        logger.warning("COMMUTE_ORIGIN or COMMUTE_DESTINATION not set")
+        return
+
+    service = LocationService()
+    info = service.get_commute_info(origin, destination)
+    if "error" in info:
+        logger.error("Commute update error: %s", info["error"])
+        return
+
+    duration = info.get("best_route", {}).get("duration", {}).get("text")
+    logger.info("Commute from %s to %s: %s", origin, destination, duration)
+
+
+def add_scheduled_jobs() -> None:
+    """Register default scheduled jobs if not already present."""
+    jobs = [
+        ("due_reminders", send_due_reminders, 60),
+        ("low_stock", check_low_stock, 300),
+        ("commute_update", update_commute_info, 600),
+    ]
+    for job_id, func, interval in jobs:
+        if not scheduler.get_job(job_id):
+            scheduler.add_job(func, "interval", seconds=interval, id=job_id)
+
+
+@router.get("/tasks")
+async def list_tasks() -> List[Dict[str, Any]]:
+    """List current scheduled tasks."""
+    result = []
+    for job in scheduler.get_jobs():
+        result.append({
+            "id": job.id,
+            "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
+            "paused": job.next_run_time is None,
+        })
+    return result
+
+
+@router.post("/enable/{task_id}")
+async def enable_task(task_id: str) -> Dict[str, str]:
+    """Resume a paused task."""
+    try:
+        scheduler.resume_job(task_id)
+        return {"message": f"{task_id} resumed"}
+    except Exception as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post("/disable/{task_id}")
+async def disable_task(task_id: str) -> Dict[str, str]:
+    """Pause a scheduled task."""
+    try:
+        scheduler.pause_job(task_id)
+        return {"message": f"{task_id} paused"}
+    except Exception as exc:
+        raise HTTPException(status_code=404, detail=str(exc))


### PR DESCRIPTION
## Summary
- add APScheduler dependency
- implement `task_scheduler` with default jobs and API
- integrate scheduler router in main app

## Testing
- `python -m py_compile main.py task_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_684642c099e8832caaed66ef41037d4d