### PR TITLE
Add auth and secure OS manager

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from .models import Token, User
+from .security import authenticate_user, create_access_token, get_current_user
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+@router.post("/token", response_model=Token)
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token = create_access_token(data={"sub": user.username, "role": user.role})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+@router.get("/me", response_model=User)
+async def read_users_me(current_user: User = Depends(get_current_user)):
+    return current_user
+
+# Re-export dependencies for convenience
+from .security import get_current_user, require_admin_user
+__all__ = ["router", "get_current_user", "require_admin_user"]

--- a/auth/models.py
+++ b/auth/models.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+class TokenData(BaseModel):
+    username: Optional[str] = None
+    role: Optional[str] = None
+
+class User(BaseModel):
+    username: str
+    role: str
+
+class UserInDB(User):
+    hashed_password: str

--- a/auth/security.py
+++ b/auth/security.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timedelta
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+import os
+from .models import UserInDB, TokenData, User
+
+SECRET_KEY = os.getenv("SECRET_KEY", "secret-key")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
+
+# In-memory user store
+admin_password = os.getenv("ADMIN_PASSWORD", "admin")
+fake_users_db = {
+    "admin": UserInDB(username="admin", role="admin", hashed_password=pwd_context.hash(admin_password))
+}
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_user(username: str) -> UserInDB | None:
+    return fake_users_db.get(username)
+
+def authenticate_user(username: str, password: str) -> User | None:
+    user = get_user(username)
+    if not user or not verify_password(password, user.hashed_password):
+        return None
+    return User(username=user.username, role=user.role)
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+def get_current_user(token: str = Depends(oauth2_scheme)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        role: str = payload.get("role")
+        if username is None:
+            raise credentials_exception
+        token_data = TokenData(username=username, role=role)
+    except JWTError:
+        raise credentials_exception
+    user_in_db = get_user(token_data.username)
+    if user_in_db is None:
+        raise credentials_exception
+    return User(username=user_in_db.username, role=user_in_db.role)
+
+def require_admin_user(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
+    return current_user

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 import uvicorn
 from pathlib import Path
 import os
@@ -8,6 +9,7 @@ from life_organizer.routers import reminders, appointments, location
 from smart_home.routers import home_control, events
 from inventory_manager.routers import inventory, receipts
 from os_manager.routers import system_info, file_system, process_mgmt
+from auth import router as auth_router
 
 # Load environment variables at startup
 load_dotenv()
@@ -19,14 +21,17 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# Add CORS middleware
+# Configure CORS and HTTPS
+allowed_origins = os.getenv("CORS_ORIGINS", "http://localhost").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, replace with specific origins
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+if os.getenv("ENV", "development").lower() == "production":
+    app.add_middleware(HTTPSRedirectMiddleware)
 
 # Include routers
 # Life Organizer
@@ -46,6 +51,9 @@ app.include_router(receipts)
 app.include_router(system_info)
 app.include_router(file_system)
 app.include_router(process_mgmt)
+
+# Auth
+app.include_router(auth_router)
 
 @app.get("/")
 async def root():

--- a/os_manager/routers/file_system.py
+++ b/os_manager/routers/file_system.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
+from auth import require_admin_user
 from typing import List, Dict, Any, Optional
 import os
 import shutil
@@ -9,6 +10,7 @@ router = APIRouter(
     prefix="/files",
     tags=["file system"],
     responses={404: {"description": "Not found"}},
+    dependencies=[Depends(require_admin_user)],
 )
 
 def get_file_info(path: Path) -> Dict[str, Any]:

--- a/os_manager/routers/process_mgmt.py
+++ b/os_manager/routers/process_mgmt.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
+from auth import require_admin_user
 from typing import List, Dict, Any, Optional
 import psutil
 import subprocess
@@ -10,6 +11,7 @@ router = APIRouter(
     prefix="/process",
     tags=["process management"],
     responses={404: {"description": "Not found"}},
+    dependencies=[Depends(require_admin_user)],
 )
 
 def get_process_info(process: psutil.Process) -> Dict[str, Any]:

--- a/os_manager/routers/system_info.py
+++ b/os_manager/routers/system_info.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from auth import require_admin_user
 from typing import List, Dict, Any
 import psutil
 import platform
@@ -9,6 +10,7 @@ router = APIRouter(
     prefix="/system",
     tags=["system"],
     responses={404: {"description": "Not found"}},
+    dependencies=[Depends(require_admin_user)],
 )
 
 @router.get("/info")


### PR DESCRIPTION
## Summary
- implement JWT-based auth in new `auth/` module
- restrict OS manager routers to admin users
- tighten CORS settings and enforce HTTPS in production

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684642b7ffe4832cb39789c5e6d2777e