### PR TITLE
Implement JWT auth and secure routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ uvicorn main:app --reload
 - OpenAPI UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 
+## Authentication
+
+Some endpoints require a valid JWT token. Default credentials can be provided
+through environment variables:
+
+```bash
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=admin
+export SECRET_KEY=mysecret
+```
+
+1. Obtain a token by sending a POST request to `/token` with `username` and
+   `password` form fields:
+
+```bash
+curl -X POST -F "username=$ADMIN_USERNAME" -F "password=$ADMIN_PASSWORD" \
+     http://localhost:8000/token
+```
+
+2. Use the returned `access_token` in the `Authorization` header to access
+   protected routes (`/process/*` and `/files/*`):
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:8000/process/list
+```
+
 ## API Endpoints
 
 ### Smart Home (`/smart-home`)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 from pathlib import Path
@@ -8,6 +8,8 @@ from life_organizer.routers import reminders, appointments, location
 from smart_home.routers import home_control, events
 from inventory_manager.routers import inventory, receipts
 from os_manager.routers import system_info, file_system, process_mgmt
+from shared.auth import Token, login_for_access_token
+from fastapi.security import OAuth2PasswordRequestForm
 
 # Load environment variables at startup
 load_dotenv()
@@ -46,6 +48,12 @@ app.include_router(receipts)
 app.include_router(system_info)
 app.include_router(file_system)
 app.include_router(process_mgmt)
+
+# Authentication token endpoint
+@app.post("/token", response_model=Token)
+async def generate_token(form_data: OAuth2PasswordRequestForm = Depends()):
+    """Issue JWT access tokens."""
+    return await login_for_access_token(form_data)
 
 @app.get("/")
 async def root():

--- a/os_manager/routers/file_system.py
+++ b/os_manager/routers/file_system.py
@@ -1,14 +1,17 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from typing import List, Dict, Any, Optional
 import os
 import shutil
 from pathlib import Path
 from datetime import datetime
 
+from shared.auth import get_current_user
+
 router = APIRouter(
     prefix="/files",
     tags=["file system"],
     responses={404: {"description": "Not found"}},
+    dependencies=[Depends(get_current_user)],
 )
 
 def get_file_info(path: Path) -> Dict[str, Any]:

--- a/os_manager/routers/process_mgmt.py
+++ b/os_manager/routers/process_mgmt.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from typing import List, Dict, Any, Optional
 import psutil
 import subprocess
@@ -6,10 +6,13 @@ import sys
 import os
 from datetime import datetime
 
+from shared.auth import get_current_user
+
 router = APIRouter(
     prefix="/process",
     tags=["process management"],
     responses={404: {"description": "Not found"}},
+    dependencies=[Depends(get_current_user)],
 )
 
 def get_process_info(process: psutil.Process) -> Dict[str, Any]:

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -1,0 +1,87 @@
+import os
+from datetime import datetime, timedelta
+from typing import Optional, Dict
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from pydantic import BaseModel
+
+# Configuration
+SECRET_KEY = os.getenv("SECRET_KEY", "change_me")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
+
+ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "admin")
+ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "admin")
+
+# Password hashing context
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# OAuth2 scheme
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+# In-memory user "database"
+_users_db: Dict[str, str] = {
+    ADMIN_USERNAME: pwd_context.hash(ADMIN_PASSWORD)
+}
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def authenticate_user(username: str, password: str) -> Optional[Dict[str, str]]:
+    hashed = _users_db.get(username)
+    if not hashed:
+        return None
+    if not verify_password(password, hashed):
+        return None
+    return {"username": username}
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme)) -> Dict[str, str]:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    if username not in _users_db:
+        raise credentials_exception
+    return {"username": username}
+
+
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()) -> Token:
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user["username"]}, expires_delta=access_token_expires
+    )
+    return Token(access_token=access_token, token_type="bearer")


### PR DESCRIPTION
## Summary
- add new `shared/auth.py` for JWT token creation and validation
- expose `/token` endpoint for obtaining tokens
- secure file system and process management routers with authentication
- document authentication workflow in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68463fcc5db8832ca9d7125be63af43c