### PR TITLE
Add env example and update README setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment configuration for Everything App
+
+# Port for the FastAPI server
+PORT=8000
+
+# Google Maps API key used by the location service
+GOOGLE_MAPS_API_KEY=
+
+# Set to 'true' to use mock location data instead of real Google Maps calls
+MOCK_LOCATION_SERVICE=false
+
+# Optional: override default SQLite database path or use another database
+# Example: postgresql://user:pass@localhost:5432/everything
+DATABASE_URL=

--- a/README.md
+++ b/README.md
@@ -32,12 +32,17 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-3. Run the application:
+3. Copy the example environment file and add your keys:
+```bash
+cp .env.example .env
+# Edit .env and populate GOOGLE_MAPS_API_KEY and other variables
+```
+4. Run the application:
 ```bash
 uvicorn main:app --reload
 ```
 
-4. Access the API documentation:
+5. Access the API documentation:
 - OpenAPI UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 


### PR DESCRIPTION
## Summary
- provide `.env.example` with commonly used environment variables
- document copying `.env.example` to `.env`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68463fca28d4832cad7dd2fb668698f3