### PR TITLE
Improve location service initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ uvicorn main:app --reload
 - OpenAPI UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 
+### Environment Variables
+
+The location service relies on the Google Maps API. Provide a valid
+`GOOGLE_MAPS_API_KEY` in your `.env` file. If `MOCK_LOCATION_SERVICE` is **not**
+set to `true` and the API key is missing or invalid, the application will raise
+a runtime error during startup.
+
 ## API Endpoints
 
 ### Smart Home (`/smart-home`)

--- a/shared/location_service.py
+++ b/shared/location_service.py
@@ -29,21 +29,21 @@ class LocationService:
 
     def _initialize_clients(self) -> None:
         """Initialize API clients with proper error handling."""
-        if not self.mock_mode:
-            try:
-                api_key = os.getenv("GOOGLE_MAPS_API_KEY")
-                if not api_key:
-                    logger.warning("GOOGLE_MAPS_API_KEY not found in environment, falling back to mock mode")
-                    self.mock_mode = True
-                    return
-                    
-                self.gmaps = googlemaps.Client(key=api_key)
-                self.tf = TimezoneFinder()
-                logger.info("Successfully initialized Google Maps client")
-            except Exception as e:
-                logger.error(f"Failed to initialize Google Maps client: {str(e)}")
-                self.mock_mode = True
-                logger.warning("Falling back to mock mode due to initialization error")
+        if self.mock_mode:
+            return
+
+        api_key = os.getenv("GOOGLE_MAPS_API_KEY")
+        if not api_key:
+            logger.error("GOOGLE_MAPS_API_KEY not found in environment")
+            raise RuntimeError("GOOGLE_MAPS_API_KEY not set")
+
+        try:
+            self.gmaps = googlemaps.Client(key=api_key)
+            self.tf = TimezoneFinder()
+            logger.info("Successfully initialized Google Maps client")
+        except Exception as e:
+            logger.error(f"Failed to initialize Google Maps client: {str(e)}")
+            raise RuntimeError("Failed to initialize Google Maps client") from e
 
     def _get_mock_location(self, address: str) -> Dict[str, Any]:
         """Generate mock location data for testing."""


### PR DESCRIPTION
## Summary
- raise `RuntimeError` if `GOOGLE_MAPS_API_KEY` is missing or initialization fails
- document the required environment variable in the README

## Testing
- `python -m py_compile shared/location_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68463b6729cc832cb1f562d9e88f636d