### PR TITLE
Update README for env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-3. Run the application:
+3. Create a `.env` file in the repository root. All services load environment
+   variables from this file when they start. Add any required keys here before
+   running the app.
+
+4. Run the application:
 ```bash
 uvicorn main:app --reload
 ```
 
-4. Access the API documentation:
+5. Access the API documentation:
 - OpenAPI UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 


### PR DESCRIPTION
## Summary
- explain that services load environment variables from `.env`
- add step to create `.env` in setup instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68463b65df2c832c91af2fd1dacd60f1