### PR TITLE
Use environment variable for mobile API URL

### DIFF
--- a/os-manager-mobile/README.md
+++ b/os-manager-mobile/README.md
@@ -19,7 +19,8 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 ### Environment configuration
 
 Create a `.env` file in the project root and set `EXPO_PUBLIC_API_URL` to the
-address of your FastAPI server. See the repository's `.env.example` for a
+address of your FastAPI server. If this variable isn't set, the app will use
+`http://localhost:8000` by default. See the repository's `.env.example` for a
 template.
 
 In the output, you'll find options to open the app in a

--- a/os-manager-mobile/src/api/system.ts
+++ b/os-manager-mobile/src/api/system.ts
@@ -12,7 +12,9 @@ interface SystemInfo {
   };
 }
 
-const API_BASE_URL = 'http://192.168.86.28:8000';
+// Base URL for API requests. Falls back to localhost when the
+// EXPO_PUBLIC_API_URL environment variable isn't defined.
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
 
 export async function fetchSystemInfo(): Promise<SystemInfo> {
   const response = await fetch(`${API_BASE_URL}/system/info`);


### PR DESCRIPTION
## Summary
- read `EXPO_PUBLIC_API_URL` when constructing API URL
- clarify environment variable usage in mobile README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c4233018832cb670faa5afc787e7